### PR TITLE
FIX : 모바일+PC헤더 겹침 문제 수정

### DIFF
--- a/src/api/activity.js
+++ b/src/api/activity.js
@@ -1,0 +1,11 @@
+import client from './client';
+
+export async function getSession(page = 0, size = 1000)  {
+    try {
+        const response = await client.get("/normal/session");
+        // console.log('프로젝트 API 응답:', response.data); 
+        return response.data;
+    } catch (error) {
+        console.error('세션 조회 에러', error);
+    }
+};

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import LogoTave from "../assets/images/LogoTave.svg";
 import HoverIcon from "../assets/images/HeaderHover.svg";
 import { useNavigate } from "react-router-dom";
@@ -7,6 +7,19 @@ export default function Header({ isBlack }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const navigate = useNavigate();
+  
+  // 화면 크기 변경 시 모바일 메뉴 자동 닫기
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768 && isMenuOpen) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [isMenuOpen]);
+
   const handleMenuToggle = () => {
     setIsMenuOpen(!isMenuOpen);
   };

--- a/src/components/stepComponent.jsx
+++ b/src/components/stepComponent.jsx
@@ -77,7 +77,7 @@ export default function StepComponent({
 
  {/* 세션 배경이미지 추가 (추후 이미지 선정 후 테스트 한 번 더 해야함) */}
             <div
-              className={`flex w-full justify-between items-center gap-3 w-88 lg:min-w-[550px] sm:py-12 py-3 rounded-2xl p-5 transition-transform duration-300 ease-in-out ${
+              className={`flex w-full justify-between items-center gap-3 w-88 lg:min-w-[550px] sm:py-12 h-44 rounded-2xl px-5 transition-transform duration-300 ease-in-out ${
                 selectedStep === index ? "scale-100" : "scale-90"
               } transition-all duration-300 ease-in-out lg:w-[800px] relative overflow-hidden`}
               style={{

--- a/src/components/stepComponent.jsx
+++ b/src/components/stepComponent.jsx
@@ -75,6 +75,7 @@ export default function StepComponent({
               />
             )}
 
+// 세션 배경이미지 추가 (추후 이미지 선정 후 테스트 한 번 더 해야함)
             <div
               className={`flex w-full justify-between items-center gap-3 w-88 lg:min-w-[550px] sm:py-12 py-3 rounded-2xl p-5 transition-transform duration-300 ease-in-out ${
                 selectedStep === index ? "scale-100" : "scale-90"

--- a/src/components/stepComponent.jsx
+++ b/src/components/stepComponent.jsx
@@ -76,21 +76,34 @@ export default function StepComponent({
             )}
 
             <div
-              className={`flex w-full justify-between gap-3 w-88 lg:min-w-[550px] sm:py-12 py-3 rounded-2xl p-5 transition-transform duration-300 ease-in-out ${
+              className={`flex w-full justify-between items-center gap-3 w-88 lg:min-w-[550px] sm:py-12 py-3 rounded-2xl p-5 transition-transform duration-300 ease-in-out ${
                 selectedStep === index ? "scale-100" : "scale-90"
-              } transition-all duration-300 ease-in-out ${
-                selectedStep === index
-                  ? "bg-[rgb(39,76,200)] text-white"
-                  : "bg-[rgba(36,36,36,0.7)] text-gray-500"
-              } lg:w-[800px]`}
+              } transition-all duration-300 ease-in-out lg:w-[800px] relative overflow-hidden`}
+              style={{
+                backgroundImage: step.imgUrl
+                  ? `linear-gradient(rgba(36, 36, 36, ${selectedStep === index ? 0.3 : 0.7}), rgba(36, 36, 36, ${selectedStep === index ? 0.3 : 0.7})), url(${step.imgUrl})`
+                  : 'none',
+                backgroundColor: step.imgUrl
+                  ? undefined
+                  : selectedStep === index
+                    ? 'rgb(39,76,200)'
+                    : 'rgba(36,36,36,0.7)',
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+                color: selectedStep === index ? 'white' : 'rgb(156, 163, 175)',
+              }}
+              
             >
               <div className="text-sm md:text-2xl font-bold break-keep text-left">
                 {step.title}
               </div>
+             
               <div className="text-xs font-medium md:text-xl text-start break-keep">
                 {step.description}
               </div>
-            </div>
+             
+              </div>
+           
           </div>
         ))}
       </div>

--- a/src/components/stepComponent.jsx
+++ b/src/components/stepComponent.jsx
@@ -75,7 +75,7 @@ export default function StepComponent({
               />
             )}
 
-// 세션 배경이미지 추가 (추후 이미지 선정 후 테스트 한 번 더 해야함)
+ {/* 세션 배경이미지 추가 (추후 이미지 선정 후 테스트 한 번 더 해야함) */}
             <div
               className={`flex w-full justify-between items-center gap-3 w-88 lg:min-w-[550px] sm:py-12 py-3 rounded-2xl p-5 transition-transform duration-300 ease-in-out ${
                 selectedStep === index ? "scale-100" : "scale-90"

--- a/src/pages/activity.jsx
+++ b/src/pages/activity.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { getSession } from '../api/activity';
 
 import Footer from '../components/footer';
 import StepComponent from '../components/stepComponent';
@@ -16,49 +17,36 @@ import Part from '../components/activity/Part';
 
 export default function Activity() {
     const navigate = useNavigate();
-    const steps = [
-        {
-            title: 'OT',
-            description: '새로운 기수를 시작하며, 다양한 활동 방법을 소개하는 세션',
-        },
-        {
-            title: 'MT',
-            description: '팀 빌딩이 이루어지기 전, 다른 TAVY들을 알아가는 세션',
-        },
-        {
-            title: '만남의 장',
-            description: 'TAVE만의 노하우가 들어간 팀 빌딩 세션',
-        },
-        {
-            title: '테버랜드',
-            description: 'OB와 YB가 다양한 콘텐츠 내에서 활동하며 네트워킹하는 세션',
-        },
-        {
-            title: '전반기 시상식',
-            description: '전반기 동안 스터디한 결과를 공유하고 시상하는 세션',
-        },
-        {
-            title: '테런데이',
-            description: '다양한 멘토들에게 직접 프로젝트 피드백을 받을 수 있는 세션',
-        },
-        {
-            title: 'OB 강연',
-            description: 'IT 업계 현직자 OB분들을 초청하여, 인사이트를 얻을 수 있는 세션',
-        },
-        {
-            title: 'TAVE의 밤',
-            description: '매 회 다른 컨셉을 두고, 전 기수가 모이는 네트워킹 센터',
-        },
-        {
-            title: 'TAVE 컨퍼런스',
-            description: '후반기 동안 개발한 후반기 프로젝트를 공유하고 시상하는 세션',
-        },
-    ];
-
+    const [steps, setSteps] = useState([]);
     const [selectedStep, setSelectedStep] = useState(0);
-    const stepRefs = useRef(steps.map(() => React.createRef()));
+    const stepRefs = useRef([]);
+
+    // getSession API로 데이터 불러오기
+    useEffect(() => {
+        const fetchSessions = async () => {
+            try {
+                const sessionData = await getSession();
+                // console.log('세션 데이터:', sessionData); 
+                
+                if (sessionData && Array.isArray(sessionData.result)) {
+                    setSteps(sessionData.result);
+                    stepRefs.current = sessionData.result.map(() => React.createRef());
+                } else {
+                    console.error('세션 데이터가 올바른 형태가 아닙니다:', sessionData);
+                    setSteps([]);
+                }
+            } catch (error) {
+                console.error('세션 데이터를 불러오는데 실패했습니다:', error);
+                setSteps([]);
+            }
+        };
+
+        fetchSessions();
+    }, []);
 
     const handleScroll = useCallback(() => {
+        if (!stepRefs.current || stepRefs.current.length === 0) return;
+        
         const scrollPosition = window.scrollY + window.innerHeight / 2;
 
         stepRefs.current.forEach((ref, index) => {
@@ -117,7 +105,9 @@ export default function Activity() {
                         <Part />
                     </div>
                     <div className="md:mb-15 mb-[45px] md:text-[40px] font-bold text-[26px] mt-96 ">정규 세션 소개</div>
-                    <StepComponent steps={steps} selectedStep={selectedStep} setSelectedStep={setSelectedStep} />
+                    {steps.length > 0 && (
+                        <StepComponent steps={steps} selectedStep={selectedStep} setSelectedStep={setSelectedStep} />
+                    )}
                 </div>
             </div>
 

--- a/src/pages/activity.jsx
+++ b/src/pages/activity.jsx
@@ -21,12 +21,12 @@ export default function Activity() {
     const [selectedStep, setSelectedStep] = useState(0);
     const stepRefs = useRef([]);
 
-    // getSession API로 데이터 불러오기
+    // getSession API로 세션 데이터 불러오는 코드 추가
     useEffect(() => {
         const fetchSessions = async () => {
             try {
                 const sessionData = await getSession();
-                // console.log('세션 데이터:', sessionData); 
+                console.log('세션 데이터:', sessionData); 
                 
                 if (sessionData && Array.isArray(sessionData.result)) {
                     setSteps(sessionData.result);

--- a/src/pages/activity.jsx
+++ b/src/pages/activity.jsx
@@ -17,32 +17,70 @@ import Part from '../components/activity/Part';
 
 export default function Activity() {
     const navigate = useNavigate();
-    const [steps, setSteps] = useState([]);
+    // const [steps, setSteps] = useState([]);
     const [selectedStep, setSelectedStep] = useState(0);
     const stepRefs = useRef([]);
 
     // getSession API로 세션 데이터 불러오는 코드 추가
-    useEffect(() => {
-        const fetchSessions = async () => {
-            try {
-                const sessionData = await getSession();
-                console.log('세션 데이터:', sessionData); 
+    // useEffect(() => {
+    //     const fetchSessions = async () => {
+    //         try {
+    //             const sessionData = await getSession();
+    //             console.log('세션 데이터:', sessionData); 
                 
-                if (sessionData && Array.isArray(sessionData.result)) {
-                    setSteps(sessionData.result);
-                    stepRefs.current = sessionData.result.map(() => React.createRef());
-                } else {
-                    console.error('세션 데이터가 올바른 형태가 아닙니다:', sessionData);
-                    setSteps([]);
-                }
-            } catch (error) {
-                console.error('세션 데이터를 불러오는데 실패했습니다:', error);
-                setSteps([]);
-            }
-        };
+    //             if (sessionData && Array.isArray(sessionData.result)) {
+    //                 setSteps(sessionData.result);
+    //                 stepRefs.current = sessionData.result.map(() => React.createRef());
+    //             } else {
+    //                 console.error('세션 데이터가 올바른 형태가 아닙니다:', sessionData);
+    //                 setSteps([]);
+    //             }
+    //         } catch (error) {
+    //             console.error('세션 데이터를 불러오는데 실패했습니다:', error);
+    //             setSteps([]);
+    //         }
+    //     };
 
-        fetchSessions();
-    }, []);
+    //     fetchSessions();
+    // }, []);
+    const steps = [
+        {
+            title: 'OT',
+            description: '새로운 기수를 시작하며, 다양한 활동 방법을 소개하는 세션',
+        },
+        {
+            title: 'MT',
+            description: '팀 빌딩이 이루어지기 전, 다른 TAVY들을 알아가는 세션',
+        },
+        {
+            title: '만남의 장',
+            description: 'TAVE만의 노하우가 들어간 팀 빌딩 세션',
+        },
+        {
+            title: '테버랜드',
+            description: 'OB와 YB가 다양한 콘텐츠 내에서 활동하며 네트워킹하는 세션',
+        },
+        {
+            title: '전반기 시상식',
+            description: '전반기 동안 스터디한 결과를 공유하고 시상하는 세션',
+        },
+        {
+            title: '테런데이',
+            description: '다양한 멘토들에게 직접 프로젝트 피드백을 받을 수 있는 세션',
+        },
+        {
+            title: 'OB 강연',
+            description: 'IT 업계 현직자 OB분들을 초청하여, 인사이트를 얻을 수 있는 세션',
+        },
+        {
+            title: 'TAVE의 밤',
+            description: '매 회 다른 컨셉을 두고, 전 기수가 모이는 네트워킹 센터',
+        },
+        {
+            title: 'TAVE 컨퍼런스',
+            description: '후반기 동안 개발한 후반기 프로젝트를 공유하고 시상하는 세션',
+        },
+    ];
 
     const handleScroll = useCallback(() => {
         if (!stepRefs.current || stepRefs.current.length === 0) return;


### PR DESCRIPTION
## 문제 상황
> 모바일+PC 버전 헤더가 중복으로 출력되는 문제

<img width="517" alt="스크린샷 2025-07-02 오후 2 27 50" src="https://github.com/user-attachments/assets/d7a7ceff-c01c-426b-9bbc-9c6887b6e4fe" />

-> 모바일 헤더를 열었을 경우

<img width="515" alt="스크린샷 2025-07-02 오후 2 27 55" src="https://github.com/user-attachments/assets/4322c482-c4e4-4c7f-aef1-0fb6d40fbcb3" />

-> **모바일 헤더를 열고 PC 버전**으로 바꿨을 경우(가로 길이 증가)
열려있던 모바일 헤더가 닫히지 않고 PC 헤더와 합쳐져서 나옴

## 작업 내용
1. 화면 크기 감지를 통해 가로 길이 변화 측정
```window.addEventListener('resize', handleResize);```
2. 모바일 크기보다 가로 길이가 클 경우, 자동으로 헤더 닫음
``` const handleResize = () => {
      if (window.innerWidth >= 768 && isMenuOpen) {
        setIsMenuOpen(false);
      }
    };```

